### PR TITLE
Fix the IWCFMonitor contract  for monitorClient.(

### DIFF
--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -17,6 +17,7 @@ namespace Client
             {
                 string retval = proxy.BeatTheBroncos(35);
                 Console.WriteLine(retval);
+                Console.Read();
 
             }
             catch (Exception ex)

--- a/MonitorClient/Program.cs
+++ b/MonitorClient/Program.cs
@@ -15,15 +15,16 @@ namespace MonitorClient
 
             try
             {
-                string[] services = proxy.GetServices();
+                var services = proxy.GetServices();
                 Console.WriteLine("Serivces" + Environment.NewLine + "-----------------");
-                foreach(string service in services)
+                foreach (string service in services)
                 {
                     Console.WriteLine(service);
                 }
                 Console.WriteLine("-----------------" + Environment.NewLine);
                 string retval = proxy.GetProcessInfo("Seahawks");
                 Console.WriteLine(retval);
+                Console.Read();
 
             }
             catch (Exception ex)

--- a/MonitorClient/monitorProxy.cs
+++ b/MonitorClient/monitorProxy.cs
@@ -8,6 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 namespace WCFMonitor
 {
     using System.Runtime.Serialization;
@@ -288,7 +289,7 @@ public interface IWCFMonitor
     WCFMonitor.ProcessInfoData GetProcessObjInfo(string ServiceName);
     
     [System.ServiceModel.OperationContractAttribute(Action="urn:WCFMonitor/IWCFMonitor/GetServices", ReplyAction="urn:WCFMonitor/IWCFMonitor/GetServicesResponse")]
-    string[] GetServices();
+    List<string> GetServices();
 }
 
 [System.CodeDom.Compiler.GeneratedCodeAttribute("System.ServiceModel", "4.0.0.0")]
@@ -335,7 +336,7 @@ public partial class WCFMonitorClient : System.ServiceModel.ClientBase<IWCFMonit
         return base.Channel.GetProcessObjInfo(ServiceName);
     }
     
-    public string[] GetServices()
+    public List<string> GetServices()
     {
         return base.Channel.GetServices();
     }


### PR DESCRIPTION
change `string[]GetServices() ` to `List<string>GetServices()` in `monitorProxy.cs` file.

fix the bug:
cannot be processed at the receiver, due to a ContractFilter mismatch at the EndpointDispatcher when using content